### PR TITLE
8-bit SIFT descriptors

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -271,10 +271,13 @@ public:
 
     @param sigma The sigma of the Gaussian applied to the input image at the octave \#0. If your image
     is captured with a weak camera with soft lenses, you might want to reduce the number.
+
+    @param useUcharDescriptors If true, the type of descriptors will be CV_8U. If false (default), it
+    will be CV_32F.
     */
     CV_WRAP static Ptr<SIFT> create(int nfeatures = 0, int nOctaveLayers = 3,
         double contrastThreshold = 0.04, double edgeThreshold = 10,
-        double sigma = 1.6);
+        double sigma = 1.6, bool useUcharDescriptors = false);
 
     CV_WRAP virtual String getDefaultName() const CV_OVERRIDE;
 };

--- a/modules/features2d/src/sift.dispatch.cpp
+++ b/modules/features2d/src/sift.dispatch.cpp
@@ -363,12 +363,12 @@ void SIFT_Impl::findScaleSpaceExtrema( const std::vector<Mat>& gauss_pyr, const 
 static
 void calcSIFTDescriptor(
         const Mat& img, Point2f ptf, float ori, float scl,
-        int d, int n, float* dst
+        int d, int n, Mat& dst, int row
 )
 {
     CV_TRACE_FUNCTION();
 
-    CV_CPU_DISPATCH(calcSIFTDescriptor, (img, ptf, ori, scl, d, n, dst),
+    CV_CPU_DISPATCH(calcSIFTDescriptor, (img, ptf, ori, scl, d, n, dst, row),
         CV_CPU_DISPATCH_MODES_ALL);
 }
 
@@ -409,7 +409,7 @@ public:
             float angle = 360.f - kpt.angle;
             if(std::abs(angle - 360.f) < FLT_EPSILON)
                 angle = 0.f;
-            calcSIFTDescriptor(img, ptf, angle, size*0.5f, d, n, descriptors.ptr<float>((int)i));
+            calcSIFTDescriptor(img, ptf, angle, size*0.5f, d, n, descriptors, i);
         }
     }
 private:
@@ -538,19 +538,12 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
         //t = (double)getTickCount();
         int dsize = descriptorSize();
         if( useUcharDescriptors )
-        {
             _descriptors.create((int)keypoints.size(), dsize, CV_8U);
-            Mat descriptors = _descriptors.getMat();
-            Mat descriptorsFloat = Mat((int)keypoints.size(), dsize, CV_32F);
-            calcDescriptors(gpyr, keypoints, descriptorsFloat, nOctaveLayers, firstOctave);
-            descriptorsFloat.assignTo(descriptors, CV_8U);
-        }
         else
-        {
             _descriptors.create((int)keypoints.size(), dsize, CV_32F);
-            Mat descriptors = _descriptors.getMat();
-            calcDescriptors(gpyr, keypoints, descriptors, nOctaveLayers, firstOctave);
-        }
+
+        Mat descriptors = _descriptors.getMat();
+        calcDescriptors(gpyr, keypoints, descriptors, nOctaveLayers, firstOctave);
         //t = (double)getTickCount() - t;
         //printf("descriptor extraction time: %g\n", t*1000./tf);
     }

--- a/modules/features2d/test/test_sift.cpp
+++ b/modules/features2d/test/test_sift.cpp
@@ -1,0 +1,34 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+TEST(Features2d_SIFT, descriptor_type)
+{
+    Mat image = imread(cvtest::findDataFile("features2d/tsukuba.png"));
+    ASSERT_FALSE(image.empty());
+
+    Mat gray;
+    cvtColor(image, gray, COLOR_BGR2GRAY);
+
+    vector<KeyPoint> keypoints;
+    Mat descriptorsFloat, descriptorsUchar;
+    Ptr<SIFT> siftFloat = cv::SIFT::create(0, 3, 0.04, 10, 1.6, false);
+    siftFloat->detectAndCompute(gray, Mat(), keypoints, descriptorsFloat, false);
+    ASSERT_EQ(descriptorsFloat.type(), CV_32F) << "type mismatch";
+
+    Ptr<SIFT> siftUchar = cv::SIFT::create(0, 3, 0.04, 10, 1.6, true);
+    siftUchar->detectAndCompute(gray, Mat(), keypoints, descriptorsUchar, false);
+    ASSERT_EQ(descriptorsUchar.type(), CV_8U) << "type mismatch";
+
+    Mat descriptorsFloat2;
+    descriptorsUchar.assignTo(descriptorsFloat2, CV_32F);
+    Mat diff = descriptorsFloat != descriptorsFloat2;
+    ASSERT_EQ(countNonZero(diff), 0) << "descriptors are not identical";
+}
+
+
+}} // namespace


### PR DESCRIPTION
Issue #10 
Simply convert the descriptor matrix to uchar after it is calculated in float32.
To reduce the overhead we will have to modify `calcSIFTDescriptor`. (changing `float*` to `template<typename T>`  may be the simplest solution?)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
